### PR TITLE
Issue 6 create item class for edit of multiple items

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -12,6 +12,8 @@ from linebot.models import (
 )
 from botsession import BotSessionInterface
 from init import * # set constants
+from template_wrapper.carousel import generate_carousel_message_for_item # original template message wrapper
+from models import (Item, Location)
 
 app = Flask(__name__)
 botSessionInterface = BotSessionInterface()
@@ -104,6 +106,19 @@ def handle_message(event):
             session['flow'] = REGISTER
         elif text == 'edit' :
             session['flow'] = EDIT
+            # create dummy items
+            items = []
+            for i in range(5):
+                item = Item(
+                    image_url = "https://s3.us-east-2.amazonaws.com/test-boto.mr-sunege.com/tmp/5qv16iyopm6idqq.jpg",
+                    description = "description" + str(i),
+                    location = Location("8916-5 Takayama-cho, Ikoma, Nara 630-0192", 34.732128, 135.732925)
+                )
+                items.append(item)
+
+            session['items'] = items
+            reply_msg = generate_carousel_message_for_item(items)
+            line_bot_api.reply_message(event.reply_token, reply_msg)
             edit_flow.handle_text_message( event, session )
 
         elif text == 'verify' :

--- a/chatbot.py
+++ b/chatbot.py
@@ -105,17 +105,13 @@ def handle_message(event):
         elif text == 'edit' :
             session['flow'] = EDIT
             edit_flow.handle_text_message( event, session )
+
         elif text == 'verify' :
             # TODO : implement verify mode function
             pass
         else:
             print( 'WARNING : no flow selected' )
-            reply_text = "Select a flow\n register / edit / verify"
-            reply_msg  = TextSendMessage(text=reply_text)
-            line_bot_api.reply_message(
-                event.reply_token,
-                reply_msg
-            )
+            warning_no_flow_selected(event)
     else:
         # when flow is set already
         flow = session.get('flow')
@@ -138,12 +134,7 @@ def handle_message(event):
     if 'flow' not in session:
         # when flow is not set
         print( 'WARNING : no flow selected' )
-        reply_text = "Select a flow\n register / edit / verify"
-        reply_msg  = TextSendMessage(text=reply_text)
-        line_bot_api.reply_message(
-            event.reply_token,
-            reply_msg
-        )
+        warning_no_flow_selected(event)
 
     else:
         # when flow is set already
@@ -169,6 +160,7 @@ def handle_message(event):
     if 'flow' not in session:
         # when flow is not set
         print( 'WARNING : no flow selected' )
+        warning_no_flow_selected(event)
     else:
         # when flow is set already
         flow = session.get('flow')
@@ -184,6 +176,14 @@ def handle_message(event):
 
         else:
             print( 'ERROR : no flow matched' )
+
+def warning_no_flow_selected(event):
+    reply_text = "Select a flow\n register / edit / verify"
+    reply_msg  = TextSendMessage(text=reply_text)
+    line_bot_api.reply_message(
+        event.reply_token,
+        reply_msg
+    )
 
 if __name__ == "__main__":
     app.run(port=8000)

--- a/chatbot.py
+++ b/chatbot.py
@@ -8,7 +8,7 @@ from linebot.exceptions import (
     InvalidSignatureError
 )
 from linebot.models import (
-    MessageEvent, TextMessage, TextSendMessage, ImageMessage, LocationMessage
+    MessageEvent, TextMessage, TextSendMessage, ImageMessage, LocationMessage, PostbackEvent
 )
 from botsession import BotSessionInterface
 from init import * # set constants
@@ -191,6 +191,33 @@ def handle_message(event):
 
         else:
             print( 'ERROR : no flow matched' )
+
+# postback handler
+@handler.add(PostbackEvent)
+def handle_postback(event):
+    session = getattr(g, 'session', None)
+
+    if 'flow' not in session:
+        # when flow is not set
+        print( 'WARNING : no flow selected' )
+        warning_no_flow_selected(event)
+    else:
+        # when flow is set already
+        flow = session.get('flow')
+        if flow == REGISTER:
+            # register_flow.handle_postback( event, session )
+            pass
+
+        elif flow == EDIT:
+            edit_flow.handle_postback( event, session )
+
+        elif flow == VERIFY:
+            # TODO : implement verify mode function
+            pass
+
+        else:
+            print( 'ERROR : no flow matched' )
+
 
 def warning_no_flow_selected(event):
     reply_text = "Select a flow\n register / edit / verify"

--- a/chatbot.py
+++ b/chatbot.py
@@ -13,7 +13,7 @@ from linebot.models import (
 from botsession import BotSessionInterface
 from init import * # set constants
 from template_wrapper.carousel import generate_carousel_message_for_item # original template message wrapper
-from models import (Item, Location)
+from models import Item
 
 app = Flask(__name__)
 botSessionInterface = BotSessionInterface()
@@ -112,14 +112,26 @@ def handle_message(event):
                 item = Item(
                     image_url = "https://s3.us-east-2.amazonaws.com/test-boto.mr-sunege.com/tmp/5qv16iyopm6idqq.jpg",
                     description = "description" + str(i),
-                    location = Location("8916-5 Takayama-cho, Ikoma, Nara 630-0192", 34.732128, 135.732925)
+                    address = "8916-5 Takayama-cho, Ikoma, Nara 630-0192",
+                    latitude = 34.732128,
+                    longitude = 135.732925
                 )
                 items.append(item)
 
-            session['items'] = items
+                # params = {
+                #         "guest"       : guestId,
+                #         "description" : item.description,
+                #         "imgUrl"      : item.image_url,
+                #         "latitude"    : item.location.latitude,
+                #         "longitude"   : item.location.longitude
+                #         }
+                # response = api_client.register_guest_item( params )
+                # print(response.json())
+
+            session['items'] = list(map(lambda item: item.__dict__, items))
+            # show items
             reply_msg = generate_carousel_message_for_item(items)
             line_bot_api.reply_message(event.reply_token, reply_msg)
-            edit_flow.handle_text_message( event, session )
 
         elif text == 'verify' :
             # TODO : implement verify mode function

--- a/flow/edit.py
+++ b/flow/edit.py
@@ -118,7 +118,7 @@ class EditFlow:
             self.basic_reply(event.reply_token, session.get('edit_target'))
 
     def handle_postback(self, event, session):
-        session['edit_item_index'] = event.postback.data
+        session['edit_item_index'] = event.postback.data.split('&')[1]
 
         self.basic_reply(event.reply_token, None)
 

--- a/flow/register.py
+++ b/flow/register.py
@@ -114,9 +114,10 @@ class RegisterFlow:
                     session.get('IMAGE'), location)
             print( r.status_code )
 
+            self.basic_reply( event.reply_token, session.get('next_input') )
             # reset flow value
             session.pop('flow')
-            self.basic_reply( event.reply_token, session.get('next_input') )
+            session.pop('next_input')
 
         else:
             # when get wrong input value

--- a/models.py
+++ b/models.py
@@ -24,3 +24,18 @@ class Session(BaseModel):
     data = BinaryJSONField()
     expiration = DateTimeField()
 
+class Item:
+    def __init__(self, image_url=None, description=None, location=None):
+        self.image_url = image_url
+        self.description = description
+        self.location = location
+
+    def register():
+        # TODO: send json to API server for register
+        pass
+
+class Location:
+    def __init__(self, address, latitude, longitude):
+        self.address = address
+        self.latitude = latitude
+        self.longitude = longitude

--- a/models.py
+++ b/models.py
@@ -25,17 +25,13 @@ class Session(BaseModel):
     expiration = DateTimeField()
 
 class Item:
-    def __init__(self, image_url=None, description=None, location=None):
+    def __init__(self, image_url=None, description=None, address=None, latitude=None, longitude=None):
         self.image_url = image_url
         self.description = description
-        self.location = location
+        self.address = address
+        self.latitude = latitude
+        self.longitude = longitude
 
     def register():
         # TODO: send json to API server for register
         pass
-
-class Location:
-    def __init__(self, address, latitude, longitude):
-        self.address = address
-        self.latitude = latitude
-        self.longitude = longitude

--- a/template_wrapper/button.py
+++ b/template_wrapper/button.py
@@ -22,3 +22,4 @@ def generate_button_message(text, thumbnail_image_url, actions = sample_actions)
                 template = button_template
             )
     return( button_message )
+

--- a/template_wrapper/carousel.py
+++ b/template_wrapper/carousel.py
@@ -13,7 +13,7 @@ def generate_carousel_message_for_item(items):
         item = items[i]
         column = CarouselColumn(text=item.description, thumbnail_image_url=item.image_url, actions=[
             PostbackTemplateAction(
-                label='edit', data=str(i)),
+                label='edit', data="edit&" + str(i)),
         ])
         columns.append(column)
 

--- a/template_wrapper/carousel.py
+++ b/template_wrapper/carousel.py
@@ -1,0 +1,23 @@
+from linebot.models import TemplateSendMessage
+from linebot.models.template import (
+    CarouselTemplate, CarouselColumn, MessageTemplateAction, PostbackTemplateAction, URITemplateAction
+)
+
+def generate_carousel_message_for_item(items):
+    """
+    param items: Item Object
+    """
+
+    columns = []
+    for i in range(len(items)):
+        item = items[i]
+        column = CarouselColumn(text=item.description, thumbnail_image_url=item.image_url, actions=[
+            PostbackTemplateAction(
+                label='edit', data=str(i)),
+        ])
+        columns.append(column)
+
+    carousel_template = CarouselTemplate(columns=columns)
+    template_message = TemplateSendMessage(alt_text='Carousel alt text', template=carousel_template)
+    return(template_message)
+


### PR DESCRIPTION
## 変更点
- `image`, `description`, `location`を別々に管理していたので，item objectにまとめた
- editコマンドを廃止し，showコマンドを追加
- showコマンドは，5つのダミーデータをカルーセルで表示する
- showコマンドで表示したカルーセルのeditボタンを押したときにeditフローへ遷移
- editボタンを押した後は，以前と一緒

## 未実装
- 編集結果の永続化 (APIサーバへのPUT)

## 関連issue
- #12 